### PR TITLE
fix(ci): update publish pipeline permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,11 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - Linter
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
 
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to enhance permissions required for publishing releases and interacting with GitHub resources.

Workflow configuration updates:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R31-R35): Added specific permissions (`contents: write`, `issues: write`, `pull-requests: write`, `id-token: write`) to enable publishing releases, commenting on issues and pull requests, and using OIDC for npm provenance.